### PR TITLE
Support allStepsNumber, currentStepNumber on tooltip component

### DIFF
--- a/src/components/CopilotModal.js
+++ b/src/components/CopilotModal.js
@@ -10,6 +10,7 @@ type Props = {
   stop: () => void,
   next: () => void,
   prev: () => void,
+  allStepsNumber: number,
   currentStepNumber: number,
   currentStep: ?Step,
   visible: boolean,
@@ -289,6 +290,8 @@ class CopilotModal extends Component<Props, State> {
           handlePrev={this.handlePrev}
           handleStop={this.handleStop}
           labels={this.props.labels}
+          allStepsNumber={this.props.allStepsNumber}
+          currentStepNumber={this.props.currentStepNumber}
         />
       </Animated.View>,
     ];

--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -10,7 +10,7 @@ import hoistStatics from 'hoist-non-react-statics';
 import CopilotModal from '../components/CopilotModal';
 import { OFFSET_WIDTH } from '../components/style';
 
-import { getFirstStep, getLastStep, getStepNumber, getPrevStep, getNextStep } from '../utilities';
+import { getFirstStep, getLastStep, getStepNumber, getPrevStep, getNextStep, getAllStepsNumber } from '../utilities';
 
 import type { Step, CopilotContext } from '../types';
 
@@ -70,6 +70,8 @@ const copilot = ({
       componentWillUnmount() {
         this.mounted = false;
       }
+
+      getAllStepsNumber = (): number => getAllStepsNumber(this.state.steps);
 
       getStepNumber = (step: ?Step = this.state.currentStep): number =>
         getStepNumber(this.state.steps, step);
@@ -206,6 +208,7 @@ const copilot = ({
               visible={this.state.visible}
               isFirstStep={this.isFirstStep()}
               isLastStep={this.isLastStep()}
+              allStepsNumber={this.getAllStepsNumber()}
               currentStepNumber={this.getStepNumber()}
               currentStep={this.state.currentStep}
               labels={labels}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -14,6 +14,10 @@ export const getStepNumber = (steps: Array<Step>, step: ?Step): number => step
     .values(steps)
     .filter(_step => _step.order <= step.order).length;
 
+export const getAllStepsNumber = (steps: Array<Step>): number => Object
+  .values(steps)
+  .length;
+
 export const getPrevStep = (steps: Array<Step>, step: ?Step): number => Object
   .values(steps)
   .filter(_step => _step.order < step.order)

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -111,6 +111,23 @@ describe('getStepNumber', () => {
   });
 });
 
+describe('getAllStepsNumber', () => {
+  test('empty steps array', () => {
+    const allStepNumber = utilities.getAllStepsNumber([]);
+    expect(allStepNumber).toBe(0);
+  });
+
+  test('non-empty steps array', () => {
+    const steps = [
+      { name: 'Step1', order: 1 },
+      { name: 'Step2', order: 2 },
+      { name: 'Step3', order: 3 },
+    ];
+
+    expect(utilities.getAllStepsNumber(steps)).toBe(3);
+  });
+});
+
 describe('getPrevStep', () => {
   test('empty steps array', () => {
     const prevStep = utilities.getPrevStep([], null);


### PR DESCRIPTION
* To support progress(e.g,  1/4, 2/4 ..., 4/4) on custom tooltip component, it gives `allStepsNumber`, `currentStepNumber` props on custom tooltip component.